### PR TITLE
refactor: Allow use only http client

### DIFF
--- a/anilibria/api/http/request.py
+++ b/anilibria/api/http/request.py
@@ -7,19 +7,17 @@ from ..error import HTTPException
 
 
 log = getLogger("anilibria.request")
-_session = ClientSession()
-__all__ = ["Request", "_session"]
+__all__ = ["Request"]
 
 
 class Request:
-    session: ClientSession = _session
-
     def __init__(self, proxy: str = None) -> None:
         """
 
         :param proxy:
         """
         self.proxy = proxy
+        self.session = ClientSession()
 
     async def request(self, method: str, url: str, data: dict = None, **kwargs):
         """
@@ -35,7 +33,7 @@ class Request:
         log.debug(
             f"Send {method} request to {url} with data: {data} and additional kwargs: {kwargs}"
         )
-        async with _session.request(method, url, params=data, **kwargs) as response:
+        async with self.session.request(method, url, params=data, **kwargs) as response:
             raw = await response.text()
             try:
                 data = loads(raw)

--- a/anilibria/client/client.py
+++ b/anilibria/client/client.py
@@ -668,3 +668,9 @@ class AniLibriaClient:
         task2 = self._loop.create_task(coro)
         gathered = gather(task1, task2)
         self._loop.run_until_complete(gathered)
+
+    async def close(self):
+        """
+        Закрывает HTTP клиент.
+        """
+        await self._http.request.session.close()


### PR DESCRIPTION
## About

Этот пулл реквест позволяет использовать только HTTP клиент без WebSocket'а.

## Checklist

- [ ] Я запустил `black` чтобы отформатировать изменения.
- [x] Я проверил, чтобы убедиться, что изменения работают.
- [ ] Это исправляет/решает [Issue](https://github.com/Damego/anilibria.py/issues).
  - #5 
- [ ] Я сделал это пулл реквест для:
  - [ ] Документация
  - [ ] Обратно несовместимые изменения
  - [ ] Новая функция/улучшение
  - [x] Исправление бага